### PR TITLE
Ajustes no rolador, Visão do narrador e criação de mesa

### DIFF
--- a/app/dashboard/banner-upload-modal.tsx
+++ b/app/dashboard/banner-upload-modal.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import Cropper, { type Area } from "react-easy-crop";
+import Swal from "sweetalert2";
+import { createClient } from "@/lib/supabase/client";
+import { recortarParaBlob } from "@/lib/crop-image";
+
+type Props = {
+  aberto: boolean;
+  onFechar: () => void;
+  onUpload: (bannerUrl: string) => void;
+};
+
+export function BannerUploadModal({ aberto, onFechar, onUpload }: Props) {
+  const [imgSrc, setImgSrc] = useState<string | null>(null);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [pixelCrop, setPixelCrop] = useState<Area | null>(null);
+  const [pending, startTransition] = useTransition();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function resetar() {
+    setImgSrc(null);
+    setCrop({ x: 0, y: 0 });
+    setZoom(1);
+    setPixelCrop(null);
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  function fechar() {
+    if (pending) return;
+    onFechar();
+    resetar();
+  }
+
+  function lerArquivo(file: File | null | undefined) {
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      Swal.fire({
+        icon: "error",
+        title: "Arquivo inválido",
+        text: "Selecione uma imagem.",
+        background: "var(--bg-card)",
+        color: "var(--text-main)",
+      });
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (e) => setImgSrc(e.target?.result as string);
+    reader.readAsDataURL(file);
+  }
+
+  useEffect(() => {
+    if (!aberto) return;
+
+    function handlePaste(e: ClipboardEvent) {
+      const file = e.clipboardData?.files[0];
+      if (file) {
+        e.preventDefault();
+        lerArquivo(file);
+      }
+    }
+
+    document.addEventListener("paste", handlePaste);
+    return () => document.removeEventListener("paste", handlePaste);
+  }, [aberto]);
+
+  const onCropComplete = useCallback((_croppedArea: Area, pxArea: Area) => {
+    setPixelCrop(pxArea);
+  }, []);
+
+  function salvar() {
+    if (!imgSrc || !pixelCrop) return;
+
+    startTransition(async () => {
+      try {
+        const blob = await recortarParaBlob(imgSrc, pixelCrop, 1200);
+        const supabase = createClient();
+        const fileName = `mesa_banner_${Date.now()}.png`;
+
+        const { error } = await supabase.storage
+          .from("avatars")
+          .upload(fileName, blob, { contentType: "image/png", upsert: true });
+        if (error) throw error;
+
+        const { data } = supabase.storage.from("avatars").getPublicUrl(fileName);
+        onUpload(data.publicUrl);
+
+        Swal.fire({
+          icon: "success",
+          title: "Banner enviado!",
+          timer: 1200,
+          showConfirmButton: false,
+          background: "var(--bg-card)",
+          color: "var(--text-main)",
+        });
+
+        onFechar();
+        resetar();
+      } catch (err) {
+        Swal.fire({
+          icon: "error",
+          title: "Erro",
+          text: err instanceof Error ? err.message : "Falha ao salvar banner.",
+          background: "var(--bg-card)",
+          color: "var(--text-main)",
+        });
+      }
+    });
+  }
+
+  if (!aberto) return null;
+
+  return (
+    <div className="modal-overlay-mesa modal-overlay-banner" onClick={fechar}>
+      <div className="modal-content-mesa auth-card modal-banner-upload" onClick={(e) => e.stopPropagation()}>
+        <h2 style={{ color: "var(--primary)", marginBottom: 10 }}>Adicionar Banner</h2>
+        <p className="banner-upload-help">Cole, arraste uma imagem ou clique para selecionar.</p>
+
+        {!imgSrc && (
+          <div
+            className="banner-upload-dropzone"
+            onClick={() => inputRef.current?.click()}
+            onDragOver={(e) => {
+              e.preventDefault();
+              (e.currentTarget as HTMLElement).classList.add("dragover");
+            }}
+            onDragLeave={(e) => (e.currentTarget as HTMLElement).classList.remove("dragover")}
+            onDrop={(e) => {
+              e.preventDefault();
+              (e.currentTarget as HTMLElement).classList.remove("dragover");
+              lerArquivo(e.dataTransfer.files[0]);
+            }}
+          >
+            <i className="fa-solid fa-image" />
+            <p>Clique, arraste ou cole a imagem aqui</p>
+            <input
+              ref={inputRef}
+              type="file"
+              accept="image/*"
+              hidden
+              onChange={(e) => lerArquivo(e.target.files?.[0])}
+            />
+          </div>
+        )}
+
+        {imgSrc && (
+          <>
+            <div className="banner-upload-cropper-area">
+              <Cropper
+                image={imgSrc}
+                crop={crop}
+                zoom={zoom}
+                aspect={16 / 6}
+                cropShape="rect"
+                showGrid={false}
+                onCropChange={setCrop}
+                onZoomChange={setZoom}
+                onCropComplete={onCropComplete}
+              />
+            </div>
+
+            <div className="banner-upload-zoom">
+              <label htmlFor="bannerUploadZoom">Zoom</label>
+              <input
+                id="bannerUploadZoom"
+                type="range"
+                min={1}
+                max={3}
+                step={0.1}
+                value={zoom}
+                onChange={(e) => setZoom(Number(e.target.value))}
+                disabled={pending}
+              />
+              <button type="button" className="btn-text" onClick={resetar} disabled={pending}>
+                Trocar
+              </button>
+            </div>
+          </>
+        )}
+
+        <div className="modal-actions" style={{ marginTop: 20 }}>
+          <button type="button" className="modal-btn-cancel" onClick={fechar} disabled={pending}>
+            Cancelar
+          </button>
+          {imgSrc && (
+            <button
+              type="button"
+              className="modal-btn-save"
+              onClick={salvar}
+              disabled={pending || !pixelCrop}
+            >
+              {pending ? "Enviando..." : "Salvar banner"}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/dashboard.css
+++ b/app/dashboard/dashboard.css
@@ -424,9 +424,132 @@
   overflow-y: auto;
 }
 
+.modal-overlay-banner {
+  z-index: 1100;
+}
+
 .modal-content-mesa {
   width: 100%;
   max-width: 400px;
+}
+
+.modal-banner-upload {
+  width: min(640px, 100%);
+  max-width: none;
+}
+
+.banner-upload-trigger {
+  width: 100%;
+  min-height: 170px;
+  border: 2px dashed var(--border);
+  background: var(--bg-surface);
+  color: var(--text-main);
+  border-radius: 14px;
+  padding: 14px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  transition: border-color 0.15s, background 0.15s, transform 0.15s;
+  box-sizing: border-box;
+}
+
+.banner-upload-trigger:hover:not(:disabled) {
+  border-color: var(--primary);
+  background: color-mix(in oklch, var(--primary) 6%, transparent);
+  transform: translateY(-1px);
+}
+
+.banner-upload-trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+
+.banner-upload-trigger img {
+  width: 100%;
+  height: 132px;
+  object-fit: cover;
+  border-radius: 10px;
+  display: block;
+}
+
+.banner-upload-trigger i {
+  font-size: 2rem;
+  color: var(--text-sec);
+}
+
+.banner-upload-trigger span {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-main);
+  text-align: center;
+}
+
+.banner-upload-hint,
+.banner-upload-help {
+  margin: 8px 0 0;
+  font-size: 0.82rem;
+  color: var(--text-sec);
+  line-height: 1.4;
+}
+
+.banner-upload-dropzone {
+  border: 2px dashed var(--border);
+  padding: 30px 20px;
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: center;
+  transition: background 0.2s, border-color 0.2s;
+  margin-top: 12px;
+}
+
+.banner-upload-dropzone:hover,
+.banner-upload-dropzone.dragover {
+  background: color-mix(in oklch, var(--primary) 6%, transparent);
+  border-color: var(--primary);
+}
+
+.banner-upload-dropzone i {
+  font-size: 2rem;
+  color: var(--text-sec);
+  display: block;
+  margin-bottom: 10px;
+}
+
+.banner-upload-dropzone p {
+  color: var(--text-sec);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.banner-upload-cropper-area {
+  position: relative;
+  width: 100%;
+  height: 260px;
+  background: #000;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-top: 12px;
+}
+
+.banner-upload-zoom {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.banner-upload-zoom label {
+  font-size: 0.8rem;
+  color: var(--text-sec);
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.banner-upload-zoom input[type="range"] {
+  flex: 1;
 }
 
 .modal-entrar-mesa {

--- a/app/dashboard/nova-mesa.tsx
+++ b/app/dashboard/nova-mesa.tsx
@@ -2,17 +2,20 @@
 
 import { useState, useTransition } from "react";
 import { criarMesa } from "./actions";
+import { BannerUploadModal } from "./banner-upload-modal";
 
 export function BotaoNovaMesa() {
   const [aberto, setAberto] = useState(false);
   const [nome, setNome] = useState("");
   const [bannerUrl, setBannerUrl] = useState("");
+  const [bannerAberto, setBannerAberto] = useState(false);
   const [erro, setErro] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
   function fechar() {
     if (pending) return;
     setAberto(false);
+    setBannerAberto(false);
     setNome("");
     setBannerUrl("");
     setErro(null);
@@ -71,16 +74,38 @@ export function BotaoNovaMesa() {
                 />
               </div>
               <div className="form-group">
-                <label htmlFor="novaMesaBanner">URL do Banner (opcional)</label>
-                <input
-                  id="novaMesaBanner"
-                  type="url"
-                  className="form-input"
-                  placeholder="https://imagem.com/banner.jpg"
-                  value={bannerUrl}
-                  onChange={(e) => setBannerUrl(e.target.value)}
+                <label>Foto do Banner (opcional)</label>
+                <button
+                  type="button"
+                  className="banner-upload-trigger"
+                  onClick={() => setBannerAberto(true)}
                   disabled={pending}
-                />
+                >
+                  {bannerUrl ? (
+                    <>
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={bannerUrl} alt="Banner selecionado" />
+                      <span>Trocar foto</span>
+                    </>
+                  ) : (
+                    <>
+                      <i className="fa-solid fa-image" />
+                      <span>Clique, arraste ou cole uma imagem</span>
+                    </>
+                  )}
+                </button>
+                <p className="banner-upload-hint">A imagem será recortada antes de salvar a mesa.</p>
+                {bannerUrl && (
+                  <button
+                    type="button"
+                    className="btn-text"
+                    onClick={() => setBannerUrl("")}
+                    disabled={pending}
+                    style={{ padding: 0, marginTop: 8 }}
+                  >
+                    Remover foto
+                  </button>
+                )}
               </div>
               {erro && (
                 <p style={{ color: "#e74c3c", fontSize: "0.85rem", marginTop: 10 }}>{erro}</p>
@@ -103,6 +128,12 @@ export function BotaoNovaMesa() {
           </div>
         </div>
       )}
+
+      <BannerUploadModal
+        aberto={bannerAberto}
+        onFechar={() => setBannerAberto(false)}
+        onUpload={(url) => setBannerUrl(url)}
+      />
     </>
   );
 }

--- a/app/narrador/[mesaId]/actions.ts
+++ b/app/narrador/[mesaId]/actions.ts
@@ -37,3 +37,52 @@ export async function removerPersonagemDaMesa(mesaId: string, personagemId: stri
   revalidatePath(`/narrador/${mesaId}`);
   revalidatePath("/dashboard");
 }
+
+export async function criarSolicitacaoTeste(
+  mesaId: string,
+  payload: {
+    pericia: string;
+    cd: number;
+    privacidadeCd: boolean;
+    privacidadeResultado: boolean;
+    alvos?: string[] | "TODOS";
+    alvosNomes?: string[];
+  },
+) {
+  const supabase = await createClient();
+  const [
+    {
+      data: { user },
+    },
+    mesa,
+  ] = await Promise.all([
+    supabase.auth.getUser(),
+    prisma.mesa.findUnique({ where: { id: mesaId }, select: { userId: true } }),
+  ]);
+
+  if (!user) throw new Error("Não autenticado.");
+  if (!mesa) throw new Error("Mesa não encontrada.");
+  if (mesa.userId !== user.id) throw new Error("Apenas o narrador pode solicitar testes.");
+
+  const mensagem = await prisma.mensagem.create({
+    data: {
+      sessionId: mesaId,
+      uid: user.id,
+      nome: "Narrador",
+      mensagem: null,
+      tipo: "teste",
+      detalhes: {
+        pericia: payload.pericia,
+        cd: payload.cd,
+        privacidadeCd: payload.privacidadeCd,
+        privacidadeResultado: payload.privacidadeResultado,
+        alvos: payload.alvos ?? "TODOS",
+        alvosNomes: payload.alvosNomes ?? [],
+        statusPorNome: {},
+      },
+    },
+  });
+
+  revalidatePath(`/narrador/${mesaId}`);
+  return mensagem;
+}

--- a/app/narrador/[mesaId]/modal-solicitar-teste.tsx
+++ b/app/narrador/[mesaId]/modal-solicitar-teste.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState } from "react";
+import Swal from "sweetalert2";
+import { criarSolicitacaoTeste } from "./actions";
+import type { MensagemSerializada } from "@/lib/mensagens";
+
+type Props = {
+  mesaId: string;
+  aberto: boolean;
+  onFechar: () => void;
+  onCriada: (msg: MensagemSerializada) => void;
+  personagens?: { id: string; nome: string; fotoUrl?: string | null }[];
+};
+
+export function ModalSolicitarTeste({ mesaId, aberto, onFechar, onCriada, personagens }: Props) {
+  const [pericia, setPericia] = useState("");
+  const [cd, setCd] = useState(10);
+  const [privacidadeCd, setPrivacidadeCd] = useState(true);
+  const [privacidadeResultado, setPrivacidadeResultado] = useState(true);
+  const [alvos, setAlvos] = useState<string[] | "TODOS">("TODOS");
+  const [enviando, setEnviando] = useState(false);
+
+  if (!aberto) return null;
+
+  async function enviar() {
+    const nomePericia = pericia.trim();
+    if (!nomePericia) return;
+    setEnviando(true);
+    try {
+      const alvosIds = alvos === "TODOS" ? "TODOS" : alvos;
+      const alvosNomes = alvos === "TODOS"
+        ? personagens?.map((p) => p.nome) ?? []
+        : (personagens ?? [])
+            .filter((p) => alvos.includes(p.id))
+            .map((p) => p.nome);
+      const msg = await criarSolicitacaoTeste(mesaId, {
+        pericia: nomePericia,
+        cd,
+        privacidadeCd,
+        privacidadeResultado,
+        alvos: alvosIds,
+        alvosNomes,
+      });
+      onCriada({
+        id: msg.id,
+        sessionId: msg.sessionId,
+        uid: msg.uid,
+        nome: msg.nome,
+        mensagem: msg.mensagem,
+        timestamp: msg.timestamp.toISOString(),
+        tipo: msg.tipo,
+        total: msg.total,
+        modificador: msg.modificador,
+        detalhes: msg.detalhes,
+      });
+      onFechar();
+      setPericia("");
+      setCd(10);
+      setPrivacidadeCd(true);
+      setPrivacidadeResultado(true);
+    } catch (error) {
+      await Swal.fire({
+        icon: "error",
+        title: "Erro",
+        text: error instanceof Error ? error.message : "Erro ao criar teste.",
+        background: "var(--bg-card)",
+        color: "var(--text-main)",
+      });
+    } finally {
+      setEnviando(false);
+    }
+  }
+
+  return (
+    <div className="narrador-modal-overlay" onClick={onFechar}>
+      <div className="narrador-modal" onClick={(e) => e.stopPropagation()}>
+        <button type="button" className="narrador-modal-close" onClick={onFechar} aria-label="Fechar">
+          ×
+        </button>
+        <h3>Pedir Teste</h3>
+        <label>
+          Perícia
+          <input type="text" value={pericia} onChange={(e) => setPericia(e.target.value)} placeholder="Ex: Atletismo" />
+        </label>
+        <label>
+          CD
+          <input type="number" value={cd} onChange={(e) => setCd(Number(e.target.value) || 0)} min={0} />
+        </label>
+        <div>
+          <div style={{ fontWeight: 800, marginBottom: 8, color: "var(--text-sec)" }}>Alvos</div>
+          <div className="alvos-grid">
+            <button
+              type="button"
+              className={"alvo-card" + (alvos === "TODOS" ? " selected" : "")}
+              onClick={() => setAlvos("TODOS")}
+              title="Selecionar Todos"
+            >
+              <div className="alvo-avatar alvo-all">
+                <i className="fas fa-users" />
+              </div>
+              <div className="alvo-nome">Todos</div>
+            </button>
+            {personagens && personagens.length > 0 && personagens.map((p) => {
+              const primeiro = p.nome.split(" ")[0] || p.nome;
+              const selected = alvos === "TODOS" ? false : (alvos as string[]).includes(p.id);
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  className={"alvo-card" + (selected ? " selected" : "")}
+                  onClick={() => {
+                    if (alvos === "TODOS") setAlvos([p.id]);
+                    else {
+                      const setA = new Set(alvos as string[]);
+                      if (setA.has(p.id)) setA.delete(p.id);
+                      else setA.add(p.id);
+                      setAlvos(Array.from(setA));
+                    }
+                  }}
+                >
+                  <div className="alvo-avatar">
+                    {p.fotoUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={p.fotoUrl} alt={p.nome} />
+                    ) : (
+                      <div className="alvo-initial">{(primeiro || "?").charAt(0)}</div>
+                    )}
+                  </div>
+                  <div className="alvo-nome">{primeiro}</div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <div style={{ marginTop: 8 }}>
+          <label className="narrador-check">
+            <input
+              type="checkbox"
+              checked={privacidadeCd}
+              onChange={(e) => setPrivacidadeCd(e.target.checked)}
+            />
+            Mostrar CD aos jogadores
+          </label>
+          <label className="narrador-check">
+            <input
+              type="checkbox"
+              checked={privacidadeResultado}
+              onChange={(e) => setPrivacidadeResultado(e.target.checked)}
+            />
+            Mostrar resultado aos jogadores
+          </label>
+        </div>
+
+        <div className="narrador-modal-actions">
+          <button type="button" className="narrador-btn-sec" onClick={onFechar}>
+            Cancelar
+          </button>
+          <button type="button" className="narrador-btn-pri" onClick={enviar} disabled={enviando}>
+            {enviando ? "Enviando..." : "Solicitar"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/narrador/[mesaId]/narrador.css
+++ b/app/narrador/[mesaId]/narrador.css
@@ -257,6 +257,150 @@
   color: var(--primary);
 }
 
+.narrador-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 20px;
+}
+
+.narrador-modal {
+  position: relative;
+  width: min(100%, 420px);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+}
+
+.narrador-modal h3 {
+  margin: 0;
+  color: var(--text-main);
+}
+
+.narrador-modal label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--text-sec);
+  font-weight: 700;
+  font-size: 0.84rem;
+}
+
+.narrador-modal input[type="text"],
+.narrador-modal input[type="number"] {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  color: var(--text-main);
+  font: inherit;
+}
+
+.narrador-check {
+  flex-direction: row !important;
+  align-items: center;
+  gap: 10px !important;
+}
+
+.narrador-modal-close {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  border: none;
+  background: transparent;
+  color: var(--text-sec);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.narrador-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.narrador-btn-sec,
+.narrador-btn-pri {
+  border: none;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.narrador-btn-sec {
+  background: var(--bg-surface);
+  color: var(--text-main);
+}
+
+.narrador-btn-pri {
+  background: var(--primary);
+  color: white;
+}
+
+/* Avatares/alvos do modal de teste */
+.alvos-grid {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.alvo-card {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  padding: 8px;
+  width: 72px;
+  height: 96px;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  color: var(--text-main);
+}
+.alvo-card.selected {
+  box-shadow: 0 6px 18px color-mix(in oklch, var(--primary) 30%, transparent);
+  border-color: var(--primary);
+}
+.alvo-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-card);
+}
+.alvo-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.alvo-initial {
+  font-weight: 800;
+  color: var(--text-sec);
+  font-size: 1.2rem;
+}
+.alvo-nome {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-main);
+  text-align: center;
+}
+.alvo-all .alvo-avatar { background: color-mix(in oklch, var(--primary) 18%, var(--bg-card)); }
+
 @media (max-width: 900px) {
   .mesa-info {
     flex-direction: column;

--- a/app/narrador/[mesaId]/narrador.css
+++ b/app/narrador/[mesaId]/narrador.css
@@ -178,6 +178,17 @@
   min-width: 0;
 }
 
+.narrador-calendario-embed {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 8px 24px -16px rgba(0, 0, 0, 0.25);
+}
+
 .narrador-grid-jogadores {
   padding: 8px 0 0;
   gap: 24px;

--- a/app/narrador/[mesaId]/page.tsx
+++ b/app/narrador/[mesaId]/page.tsx
@@ -2,8 +2,10 @@ import { notFound, redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { createClient } from "@/lib/supabase/server";
 import { listarMensagensSessao } from "@/lib/mensagens";
+import { carregarCalendario } from "@/lib/calendario/carregar";
 import { NarradorShell } from "./painel-narrador";
 import "@/app/dashboard/dashboard.css";
+import "@/app/calendario/[mesaId]/calendario.css";
 import "./narrador.css";
 
 type Params = { params: Promise<{ mesaId: string }> };
@@ -17,8 +19,8 @@ export default async function NarradorPage({ params }: Params) {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  // Mesa + mensagens pré-carregadas em paralelo (sessionId === mesaId aqui).
-  const [mesa, mensagensIniciais] = await Promise.all([
+  // Mesa + mensagens + calendário pré-carregados em paralelo.
+  const [mesa, mensagensIniciais, calendario] = await Promise.all([
     prisma.mesa.findUnique({
       where: { id: mesaId },
       include: {
@@ -28,12 +30,21 @@ export default async function NarradorPage({ params }: Params) {
       },
     }),
     listarMensagensSessao(mesaId),
+    carregarCalendario(mesaId, { isNarrador: true }),
   ]);
   if (!mesa) notFound();
+  if (!calendario) notFound();
 
   if (mesa.userId !== user.id) {
     redirect("/dashboard");
   }
 
-  return <NarradorShell mesa={mesa} userId={user.id} mensagensIniciais={mensagensIniciais} />;
+  return (
+    <NarradorShell
+      mesa={mesa}
+      userId={user.id}
+      mensagensIniciais={mensagensIniciais}
+      calendario={calendario}
+    />
+  );
 }

--- a/app/narrador/[mesaId]/painel-narrador.tsx
+++ b/app/narrador/[mesaId]/painel-narrador.tsx
@@ -10,6 +10,7 @@ import { CopyCodigoBadge } from "./copy-codigo-badge";
 import { NarradorRealtime } from "./realtime-refresher";
 import { Bandeja } from "@/components/bandeja/bandeja";
 import { ThemeButton } from "@/components/temas/theme-button";
+import { ModalSolicitarTeste } from "./modal-solicitar-teste";
 
 type Personagem = {
   id: string;
@@ -81,6 +82,8 @@ const ACOES_PROTOTIPO = [
 
 export function NarradorShell({ mesa, userId, mensagensIniciais }: Props) {
   const [aba, setAba] = useState<Aba>("jogadores");
+  const [modalTesteAberto, setModalTesteAberto] = useState(false);
+  const [mensagemCriada, setMensagemCriada] = useState<MensagemSerializada | null>(null);
 
   return (
     <div className="narrador-container">
@@ -209,6 +212,10 @@ export function NarradorShell({ mesa, userId, mensagensIniciais }: Props) {
                     type="button"
                     className="acao-narrador-card"
                     onClick={() => {
+                      if (acao.id === "testes") {
+                        setModalTesteAberto(true);
+                        return;
+                      }
                       void Swal.fire({
                         icon: "info",
                         title: "Protótipo",
@@ -232,6 +239,15 @@ export function NarradorShell({ mesa, userId, mensagensIniciais }: Props) {
         userName={`Narrador (${mesa.nome})`}
         sessionId={mesa.id}
         mensagensIniciais={mensagensIniciais}
+        mensagemExternaCriada={mensagemCriada}
+      />
+
+      <ModalSolicitarTeste
+        mesaId={mesa.id}
+        aberto={modalTesteAberto}
+        onFechar={() => setModalTesteAberto(false)}
+        onCriada={(msg) => setMensagemCriada(msg)}
+        personagens={mesa.personagens.map((p) => ({ id: p.id, nome: p.nome, fotoUrl: p.fotoUrl }))}
       />
     </div>
   );

--- a/app/narrador/[mesaId]/painel-narrador.tsx
+++ b/app/narrador/[mesaId]/painel-narrador.tsx
@@ -11,6 +11,9 @@ import { NarradorRealtime } from "./realtime-refresher";
 import { Bandeja } from "@/components/bandeja/bandeja";
 import { ThemeButton } from "@/components/temas/theme-button";
 import { ModalSolicitarTeste } from "./modal-solicitar-teste";
+import { CalendarioRealtime } from "@/app/calendario/[mesaId]/realtime-refresher";
+import { CalendarioView } from "@/app/calendario/[mesaId]/calendario-view";
+import type { CalendarioCarregado } from "@/lib/calendario/carregar";
 
 type Personagem = {
   id: string;
@@ -35,19 +38,12 @@ type Props = {
   mesa: Mesa;
   userId: string;
   mensagensIniciais: MensagemSerializada[];
+  calendario: CalendarioCarregado;
 };
 
-type Aba = "jogadores" | "acoes";
+type Aba = "jogadores" | "acoes" | "calendario";
 
 const ACOES_PROTOTIPO = [
-  {
-    id: "calendario",
-    titulo: "Calendário",
-    icone: "fa-calendar-days",
-    descricao: "Abrir o calendário da mesa como narrador.",
-    href: (mesaId: string) => `/calendario/${mesaId}`,
-    destaque: true,
-  },
   {
     id: "testes",
     titulo: "Pedir Testes",
@@ -80,7 +76,7 @@ const ACOES_PROTOTIPO = [
   },
 ] as const;
 
-export function NarradorShell({ mesa, userId, mensagensIniciais }: Props) {
+export function NarradorShell({ mesa, userId, mensagensIniciais, calendario }: Props) {
   const [aba, setAba] = useState<Aba>("jogadores");
   const [modalTesteAberto, setModalTesteAberto] = useState(false);
   const [mensagemCriada, setMensagemCriada] = useState<MensagemSerializada | null>(null);
@@ -108,13 +104,9 @@ export function NarradorShell({ mesa, userId, mensagensIniciais }: Props) {
               <h1>{mesa.nome}</h1>
             </div>
             <div className="mesa-acoes">
-              <Link
-                href={`/calendario/${mesa.id}`}
-                className="codigo-badge"
-                style={{ textDecoration: "none" }}
-              >
-                <i className="fas fa-calendar-days" /> Calendário
-              </Link>
+              <div className="codigo-badge" aria-label="Calendário integrado">
+                <i className="fas fa-calendar-days" /> Calendário integrado
+              </div>
               <CopyCodigoBadge codigo={mesa.codigoAcesso} />
             </div>
           </div>
@@ -134,6 +126,13 @@ export function NarradorShell({ mesa, userId, mensagensIniciais }: Props) {
             onClick={() => setAba("acoes")}
           >
             <i className="fas fa-sparkles" /> Ações do Narrador
+          </button>
+          <button
+            type="button"
+            className={"narrador-tab" + (aba === "calendario" ? " active" : "")}
+            onClick={() => setAba("calendario")}
+          >
+            <i className="fas fa-calendar-days" /> Calendário
           </button>
         </nav>
 
@@ -179,6 +178,18 @@ export function NarradorShell({ mesa, userId, mensagensIniciais }: Props) {
                 })
               )}
             </section>
+          ) : aba === "calendario" ? (
+            <section className="narrador-calendario-embed">
+              <CalendarioRealtime mesaId={mesa.id} calendarioId={calendario.id} />
+              <CalendarioView
+                mesaId={mesa.id}
+                isNarrador={true}
+                config={calendario.config}
+                dataAtualDias={calendario.dataAtualDias}
+                eventos={calendario.eventos}
+                tiposClima={calendario.tiposClima}
+              />
+            </section>
           ) : (
             <section className="acoes-narrador-grid">
               {ACOES_PROTOTIPO.map((acao) => {
@@ -192,19 +203,11 @@ export function NarradorShell({ mesa, userId, mensagensIniciais }: Props) {
                       <p>{acao.descricao}</p>
                     </div>
                     <div className="acao-card-rodape">
-                      <span>{acao.id === "calendario" ? "Disponível agora" : "Protótipo"}</span>
+                      <span>Protótipo</span>
                       <i className="fas fa-arrow-right" />
                     </div>
                   </>
                 );
-
-                if (acao.id === "calendario") {
-                  return (
-                    <Link key={acao.id} href={acao.href(mesa.id)} className="acao-narrador-card">
-                      {conteudo}
-                    </Link>
-                  );
-                }
 
                 return (
                   <button

--- a/app/theme-script.tsx
+++ b/app/theme-script.tsx
@@ -1,3 +1,5 @@
+import Script from "next/script";
+
 // Script anti-flash de tema: roda ANTES do primeiro render, sincronamente.
 // Lê localStorage.temaId e aplica as variáveis CSS em :root, evitando que
 // o usuário veja o tema padrão piscando antes do tema dele carregar.
@@ -130,5 +132,5 @@ const script = `
 `;
 
 export function ThemeScript() {
-  return <script dangerouslySetInnerHTML={{ __html: script }} />;
+  return <Script id="theme-script" strategy="beforeInteractive" dangerouslySetInnerHTML={{ __html: script }} />;
 }

--- a/components/bandeja/actions.ts
+++ b/components/bandeja/actions.ts
@@ -50,7 +50,35 @@ type RolagemPayload = {
   detalhes: unknown;
   modificador: number;
   nomePreset?: string | null;
+  tipoTeste?: boolean;
+  pericia?: string | null;
+  cd?: number | null;
+  sucesso?: boolean | null;
+  privacidadeResultado?: boolean | null;
+  solicitacaoTesteId?: string | null;
+  alvoNome?: string | null;
 };
+
+function obterStatusTeste(
+  rolagem: RolagemPayload,
+  detalhes: { rolls?: Array<{ resultado: number }> } | null,
+): string {
+  const primeiroDado = detalhes?.rolls?.[0]?.resultado;
+  if (primeiroDado === 20) return "Sucesso Crítico (20 no dado)";
+  if (primeiroDado === 1) return "Falha Crítica (1 no dado)";
+  if (rolagem.sucesso === true) return "Sucesso";
+  if (rolagem.sucesso === false) return "Falha";
+  return "Aguardando resultado";
+}
+
+function extrairRoladas(detalhes: unknown): Array<{ resultado: number }> {
+  if (Array.isArray(detalhes)) return detalhes as Array<{ resultado: number }>;
+  if (detalhes && typeof detalhes === "object" && "rolls" in detalhes) {
+    const rolls = (detalhes as { rolls?: Array<{ resultado: number }> }).rolls;
+    return rolls || [];
+  }
+  return [];
+}
 
 // Combina envio de rolagem + persistência de ultimaRolagem no personagem (se houver)
 // numa única chamada com queries em paralelo no servidor.
@@ -74,6 +102,12 @@ export async function registrarRolagem(
       detalhes: {
         rolls: rolagem.detalhes,
         nomePreset: rolagem.nomePreset || null,
+        tipoTeste: rolagem.tipoTeste || null,
+        pericia: rolagem.pericia || null,
+        cd: rolagem.cd ?? null,
+        sucesso: rolagem.sucesso ?? null,
+        privacidadeResultado: rolagem.privacidadeResultado ?? null,
+        solicitacaoTesteId: rolagem.solicitacaoTesteId ?? null,
       } as Prisma.InputJsonValue,
     },
   });
@@ -86,7 +120,43 @@ export async function registrarRolagem(
         })
       : Promise.resolve(null);
 
-  const [nova] = await Promise.all([criar, atualizarPersonagem]);
+  const nova = await criar;
+  await atualizarPersonagem;
+
+  if (rolagem.solicitacaoTesteId && rolagem.alvoNome) {
+    const solicitacao = await prisma.mensagem.findUnique({
+      where: { id: rolagem.solicitacaoTesteId },
+      select: { detalhes: true },
+    });
+    const detalhesSolicitacao = (solicitacao?.detalhes as {
+      statusPorNome?: Record<string, string>;
+      pericia?: string | null;
+      cd?: number | null;
+      privacidadeCd?: boolean;
+      privacidadeResultado?: boolean;
+      alvos?: string[] | "TODOS";
+      alvosNomes?: string[];
+    } | null) ?? null;
+
+    if (detalhesSolicitacao) {
+      const statusAtualizado = obterStatusTeste(rolagem, {
+        rolls: extrairRoladas(rolagem.detalhes),
+      });
+      await prisma.mensagem.update({
+        where: { id: rolagem.solicitacaoTesteId },
+        data: {
+          detalhes: {
+            ...detalhesSolicitacao,
+            statusPorNome: {
+              ...(detalhesSolicitacao.statusPorNome || {}),
+              [rolagem.alvoNome]: statusAtualizado,
+            },
+          } as Prisma.InputJsonValue,
+        },
+      });
+    }
+  }
+
   return serializarMensagem(nova);
 }
 

--- a/components/bandeja/actions.ts
+++ b/components/bandeja/actions.ts
@@ -7,6 +7,7 @@ import {
   serializarMensagem,
   type MensagemSerializada,
 } from "@/lib/mensagens";
+import type { DadoRolado, ModoRolagem } from "@/lib/dice";
 import type { Prisma } from "@prisma/client";
 
 async function requireUser() {
@@ -45,10 +46,16 @@ export async function enviarMensagemTexto(
   return serializarMensagem(nova);
 }
 
-type RolagemPayload = {
+type RolagemExecucaoPayload = {
   total: number;
-  detalhes: unknown;
   modificador: number;
+  modo: ModoRolagem;
+  detalhes: DadoRolado[];
+};
+
+type BaseRolagemPayload = {
+  modificador: number;
+  modo: ModoRolagem;
   nomePreset?: string | null;
   tipoTeste?: boolean;
   pericia?: string | null;
@@ -58,6 +65,21 @@ type RolagemPayload = {
   solicitacaoTesteId?: string | null;
   alvoNome?: string | null;
 };
+
+type RolagemUnitariaPayload = BaseRolagemPayload & {
+  tipo: "rolagem";
+  total: number;
+  detalhes: DadoRolado[];
+};
+
+type RolagemLotePayload = BaseRolagemPayload & {
+  tipo: "lote";
+  total: number | null;
+  quantidade: number;
+  execucoes: RolagemExecucaoPayload[];
+};
+
+type RolagemPayload = RolagemUnitariaPayload | RolagemLotePayload;
 
 function obterStatusTeste(
   rolagem: RolagemPayload,
@@ -80,6 +102,13 @@ function extrairRoladas(detalhes: unknown): Array<{ resultado: number }> {
   return [];
 }
 
+function extrairRoladasDoPayload(rolagem: RolagemPayload): Array<{ resultado: number }> {
+  if (rolagem.tipo === "lote") {
+    return rolagem.execucoes[0]?.detalhes || [];
+  }
+  return rolagem.detalhes;
+}
+
 // Combina envio de rolagem + persistência de ultimaRolagem no personagem (se houver)
 // numa única chamada com queries em paralelo no servidor.
 export async function registrarRolagem(
@@ -99,16 +128,39 @@ export async function registrarRolagem(
       tipo: "rolagem",
       total: rolagem.total,
       modificador: rolagem.modificador,
-      detalhes: {
-        rolls: rolagem.detalhes,
-        nomePreset: rolagem.nomePreset || null,
-        tipoTeste: rolagem.tipoTeste || null,
-        pericia: rolagem.pericia || null,
-        cd: rolagem.cd ?? null,
-        sucesso: rolagem.sucesso ?? null,
-        privacidadeResultado: rolagem.privacidadeResultado ?? null,
-        solicitacaoTesteId: rolagem.solicitacaoTesteId ?? null,
-      } as Prisma.InputJsonValue,
+      detalhes: (
+        rolagem.tipo === "lote"
+          ? {
+              kind: "lote",
+              modo: rolagem.modo,
+              quantidade: rolagem.quantidade,
+              execucoes: rolagem.execucoes.map((execucao) => ({
+                total: execucao.total,
+                modificador: execucao.modificador,
+                modo: execucao.modo,
+                rolls: execucao.detalhes,
+              })),
+              nomePreset: rolagem.nomePreset || null,
+              tipoTeste: rolagem.tipoTeste || null,
+              pericia: rolagem.pericia || null,
+              cd: rolagem.cd ?? null,
+              sucesso: rolagem.sucesso ?? null,
+              privacidadeResultado: rolagem.privacidadeResultado ?? null,
+              solicitacaoTesteId: rolagem.solicitacaoTesteId ?? null,
+            }
+          : {
+              kind: "rolagem",
+              modo: rolagem.modo,
+              rolls: rolagem.detalhes,
+              nomePreset: rolagem.nomePreset || null,
+              tipoTeste: rolagem.tipoTeste || null,
+              pericia: rolagem.pericia || null,
+              cd: rolagem.cd ?? null,
+              sucesso: rolagem.sucesso ?? null,
+              privacidadeResultado: rolagem.privacidadeResultado ?? null,
+              solicitacaoTesteId: rolagem.solicitacaoTesteId ?? null,
+            }
+      ) as Prisma.InputJsonValue,
     },
   });
 
@@ -140,7 +192,7 @@ export async function registrarRolagem(
 
     if (detalhesSolicitacao) {
       const statusAtualizado = obterStatusTeste(rolagem, {
-        rolls: extrairRoladas(rolagem.detalhes),
+        rolls: extrairRoladasDoPayload(rolagem),
       });
       await prisma.mensagem.update({
         where: { id: rolagem.solicitacaoTesteId },

--- a/components/bandeja/actions.ts
+++ b/components/bandeja/actions.ts
@@ -64,8 +64,8 @@ function obterStatusTeste(
   detalhes: { rolls?: Array<{ resultado: number }> } | null,
 ): string {
   const primeiroDado = detalhes?.rolls?.[0]?.resultado;
-  if (primeiroDado === 20) return "Sucesso Crítico (20 no dado)";
-  if (primeiroDado === 1) return "Falha Crítica (1 no dado)";
+  if (primeiroDado === 20) return "Sucesso Crítico";
+  if (primeiroDado === 1) return "Falha Crítica";
   if (rolagem.sucesso === true) return "Sucesso";
   if (rolagem.sucesso === false) return "Falha";
   return "Aguardando resultado";

--- a/components/bandeja/bandeja.css
+++ b/components/bandeja/bandeja.css
@@ -199,15 +199,59 @@
   gap: 10px;
   align-items: flex-end;
 }
-.tray-footer input {
+.roll-footer-row {
+  align-items: flex-end;
+  gap: 8px;
+}
+.roll-footer-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  font-size: 0.7rem;
+  color: var(--text-sec);
+  align-items: center;
+  text-align: center;
+}
+.roll-footer-field input {
   width: 100%;
-  padding: 8px;
+  padding: 8px 10px;
   text-align: center;
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--bg-card);
   color: var(--text-main);
   font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1;
+  box-sizing: border-box;
+  font-variant-numeric: tabular-nums;
+}
+.roll-footer-separator {
+  font-weight: 900;
+  color: var(--text-sec);
+  padding-bottom: 11px;
+  flex-shrink: 0;
+}
+.roll-footer-mod {
+  flex-basis: 120px;
+  max-width: 140px;
+}
+.tray-footer input {
+  width: 100%;
+  padding: 8px 10px;
+  text-align: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-card);
+  color: var(--text-main);
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1;
+  box-sizing: border-box;
+  font-variant-numeric: tabular-nums;
 }
 .clear-btn {
   background: var(--bg-button);
@@ -230,6 +274,71 @@
   box-shadow: 0 4px 0 #2980b9;
   transition: 0.1s;
   font-family: inherit;
+}
+.roll-toggle-btn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  font-size: 0.62rem;
+  padding: 10px 8px;
+  line-height: 1;
+  min-width: 0;
+  min-height: 40px;
+  box-sizing: border-box;
+  overflow: hidden;
+  white-space: nowrap;
+  background: var(--bg-button);
+  color: var(--text-sec);
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0 4px 0 color-mix(in oklch, var(--border) 78%, #000 22%);
+  transition: 0.1s;
+  font-family: inherit;
+}
+.roll-toggle-btn.vantagem {
+  color: #1e8e3e;
+  box-shadow: 0 4px 0 #1e8e3e;
+}
+.roll-toggle-btn.desvantagem {
+  color: #c0392b;
+  box-shadow: 0 4px 0 #a93226;
+}
+.roll-toggle-btn.vantagem.active {
+  background: #27ae60;
+  color: white;
+  box-shadow: 0 4px 0 #1e8e3e;
+}
+.roll-toggle-btn.desvantagem.active {
+  background: #c0392b;
+  color: white;
+  box-shadow: 0 4px 0 #a93226;
+}
+.roll-toggle-btn.vantagem:not(.active) {
+  background: var(--bg-button);
+  box-shadow: 0 4px 0 #1e8e3e;
+}
+.roll-toggle-btn.desvantagem:not(.active) {
+  background: var(--bg-button);
+  box-shadow: 0 4px 0 #a93226;
+}
+.roll-toggle-btn:active {
+  transform: translateY(4px);
+  box-shadow: none;
+}
+.roll-toggle-btn i {
+  flex-shrink: 0;
+  font-size: 0.68rem;
+}
+.roll-toggle-btn span {
+  font-size: 0.62rem;
+  font-weight: 800;
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 .roll-btn:active {
   transform: translateY(4px);
@@ -259,6 +368,55 @@
   flex-shrink: 0;
   color: var(--text-main);
 }
+.roll-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 10px;
+  align-items: center;
+}
+.roll-mode-switch {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  width: 100%;
+  max-width: 360px;
+  justify-items: stretch;
+}
+.roll-mode-btn {
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-sec);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 0.76rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: 0.15s ease;
+}
+.roll-toggle-btn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  padding: 11px 12px;
+  line-height: 1;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.roll-toggle-btn i {
+  flex-shrink: 0;
+}
+.roll-toggle-btn span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .crit-success {
   color: #27ae60;
   font-weight: 900;
@@ -267,6 +425,10 @@
 .crit-fail {
   color: #c0392b;
   font-weight: 900;
+}
+.dice-discarded {
+  opacity: 0.48;
+  text-decoration: line-through;
 }
 
 /* ─── Chat ───────────────────────────────────────────────── */
@@ -331,11 +493,78 @@
   margin-top: 2px;
   word-break: break-all;
 }
-.roll-tags {
+.roll-batch-list {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 6px;
-  padding: 0 10px 8px 10px;
+  margin-top: 8px;
+  text-align: left;
+}
+.roll-batch-row {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: 8px;
+  align-items: center;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--primary) 10%, var(--bg-card));
+}
+.roll-batch-index {
+  font-size: 0.72rem;
+  font-weight: 800;
+  color: var(--text-sec);
+}
+.roll-batch-total {
+  font-weight: 900;
+  color: var(--primary);
+}
+
+.roll-mode-tag {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: var(--text-main);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  padding: 6px 10px;
+  border-radius: 8px;
+  width: fit-content;
+  font-size: 0.78rem;
+  letter-spacing: 0.01em;
+}
+.roll-mode-tag i {
+  color: var(--primary);
+}
+.roll-toggle-btn.active i {
+  color: inherit;
+}
+
+@media (max-width: 640px) {
+  .roll-mode-switch {
+    grid-template-columns: 1fr;
+  }
+
+  .roll-footer-row {
+    flex-wrap: wrap;
+  }
+
+  .roll-footer-mod {
+    max-width: none;
+    flex-basis: 100%;
+  }
+
+  .roll-footer-separator {
+    display: none;
+  }
+
+  .roll-batch-row {
+    grid-template-columns: auto 1fr;
+  }
+
+  .roll-batch-formula {
+    grid-column: 1 / -1;
+  }
 }
 
 .teste-message {

--- a/components/bandeja/bandeja.css
+++ b/components/bandeja/bandeja.css
@@ -202,6 +202,7 @@
 .roll-footer-row {
   align-items: flex-end;
   gap: 8px;
+  justify-content: center;
 }
 .roll-footer-field {
   display: flex;
@@ -212,10 +213,11 @@
   color: var(--text-sec);
   align-items: center;
   text-align: center;
+  min-width: 0;
 }
 .roll-footer-field input {
   width: 100%;
-  padding: 8px 10px;
+  padding: 8px 8px;
   text-align: center;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -224,7 +226,7 @@
   font-family: inherit;
   font-size: 0.95rem;
   font-weight: 700;
-  line-height: 1;
+  line-height: 1.15;
   box-sizing: border-box;
   font-variant-numeric: tabular-nums;
 }
@@ -240,7 +242,7 @@
 }
 .tray-footer input {
   width: 100%;
-  padding: 8px 10px;
+  padding: 8px 8px;
   text-align: center;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -249,7 +251,7 @@
   font-family: inherit;
   font-size: 0.95rem;
   font-weight: 700;
-  line-height: 1;
+  line-height: 1.15;
   box-sizing: border-box;
   font-variant-numeric: tabular-nums;
 }

--- a/components/bandeja/bandeja.css
+++ b/components/bandeja/bandeja.css
@@ -331,15 +331,11 @@
   margin-top: 2px;
   word-break: break-all;
 }
-.roll-preset-tag {
-  background: var(--primary);
-  color: white;
-  font-size: 0.72rem;
-  font-weight: 700;
-  padding: 2px 10px;
+.roll-tags {
   display: flex;
-  align-items: center;
-  gap: 5px;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 10px 8px 10px;
 }
 
 .teste-message {
@@ -349,19 +345,26 @@
 }
 .teste-box {
   background: var(--bg-card);
-  padding: 10px 12px 12px;
+  padding: 12px 14px 14px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
-.teste-titulo {
+.teste-pericia-tag {
   display: flex;
   align-items: center;
   gap: 8px;
   font-weight: 700;
   color: var(--text-main);
+  background: color-mix(in oklch, var(--primary) 18%, transparent);
+  border: 1px solid var(--primary);
+  padding: 6px 10px;
+  border-radius: 8px;
+  width: fit-content;
+  font-size: 0.78rem;
+  letter-spacing: 0.01em;
 }
-.teste-titulo i {
+.teste-pericia-tag i {
   color: var(--primary);
 }
 .teste-envolvidos {
@@ -383,7 +386,7 @@
   color: var(--text-sec);
   font-weight: 700;
 }
-.teste-mod-label {
+.teste-status-label {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -391,7 +394,8 @@
   color: var(--text-sec);
   font-weight: 700;
 }
-.teste-mod-label input {
+.teste-status-label input,
+.teste-status-label select {
   width: 100%;
   padding: 7px 8px;
   border: 1px solid var(--border);
@@ -418,6 +422,11 @@
   border: 1px solid var(--border);
   cursor: not-allowed;
 }
+.teste-btn-done {
+  background: var(--bg-surface);
+  color: var(--text-sec);
+  border: 1px solid var(--border);
+}
 .teste-notificacao {
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -428,6 +437,95 @@
   border-radius: 8px;
   padding: 10px 12px;
 }
+.teste-notificacao-narrador {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+}
+.teste-notificacao-topo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 800;
+}
+.teste-notificacao-topo i {
+  color: var(--primary);
+}
+.teste-notificacao-subtexto {
+  font-size: 0.8rem;
+  color: var(--text-sec);
+  line-height: 1.35;
+}
+.teste-dropdown-icone {
+  margin-left: auto;
+  transition: transform 0.18s ease;
+}
+.teste-acompanhamento-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  color: var(--text-main);
+  padding: 9px 12px;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+.teste-acompanhamento-toggle .teste-dropdown-icone {
+  margin-left: auto;
+}
+.teste-acompanhamento-toggle.open .teste-dropdown-icone {
+  transform: rotate(180deg);
+}
+.teste-acompanhamento {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.22s ease;
+}
+.teste-acompanhamento.open {
+  grid-template-rows: 1fr;
+}
+.teste-acompanhamento-lista {
+  overflow: hidden;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.teste-acompanhamento-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-top: 8px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-main);
+}
+.teste-acompanhamento-item .status {
+  color: var(--text-sec);
+  font-weight: 600;
+}
+.teste-acompanhamento-item.vazia {
+  justify-content: center;
+  color: var(--text-sec);
+}
+.teste-meta-linha {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
 .teste-select {
   width: 100%;
   padding: 10px 12px;
@@ -437,7 +535,6 @@
   color: var(--text-main);
   font-family: inherit;
 }
-
 .chat-input-row {
   display: flex;
   gap: 8px;

--- a/components/bandeja/bandeja.css
+++ b/components/bandeja/bandeja.css
@@ -302,6 +302,12 @@
   border-left: 3px solid var(--primary);
   flex-shrink: 0;
 }
+.roll-message.success {
+  border-left-color: #27ae60;
+}
+.roll-message.fail {
+  border-left-color: #c0392b;
+}
 .roll-header {
   font-size: 0.78rem;
   color: var(--text-sec);
@@ -334,6 +340,102 @@
   display: flex;
   align-items: center;
   gap: 5px;
+}
+
+.teste-message {
+  padding: 0;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.teste-box {
+  background: var(--bg-card);
+  padding: 10px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.teste-titulo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: var(--text-main);
+}
+.teste-titulo i {
+  color: var(--primary);
+}
+.teste-envolvidos {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.teste-envolvido-chip {
+  background: color-mix(in oklch, var(--primary) 14%, var(--bg-card));
+  border: 1px solid color-mix(in oklch, var(--primary) 32%, var(--border));
+  color: var(--text-main);
+  font-size: 0.72rem;
+  font-weight: 800;
+  padding: 4px 8px;
+  border-radius: 999px;
+}
+.teste-cd {
+  font-size: 0.78rem;
+  color: var(--text-sec);
+  font-weight: 700;
+}
+.teste-mod-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.75rem;
+  color: var(--text-sec);
+  font-weight: 700;
+}
+.teste-mod-label input {
+  width: 100%;
+  padding: 7px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-main);
+  font-family: inherit;
+}
+.teste-btn {
+  border: none;
+  border-radius: 6px;
+  background: var(--primary);
+  color: white;
+  padding: 8px 10px;
+  font-weight: 800;
+  cursor: pointer;
+  font-family: inherit;
+}
+.teste-btn:disabled {
+  background: var(--bg-surface);
+  color: var(--text-sec);
+  opacity: 1;
+  box-shadow: none;
+  border: 1px solid var(--border);
+  cursor: not-allowed;
+}
+.teste-notificacao {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  color: var(--text-main);
+  font-size: 0.85rem;
+  font-weight: 700;
+  line-height: 1.35;
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.teste-select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  color: var(--text-main);
+  font-family: inherit;
 }
 
 .chat-input-row {

--- a/components/bandeja/bandeja.tsx
+++ b/components/bandeja/bandeja.tsx
@@ -11,6 +11,8 @@ type Props = {
   userName: string;
   sessionId: string;
   personagemId?: string | null;
+  onMensagemCriada?: (msg: MensagemSerializada) => void;
+  mensagemExternaCriada?: MensagemSerializada | null;
   // Pré-carregadas no SSR — passadas direto pro PainelChat como estado inicial.
   mensagensIniciais: MensagemSerializada[];
 };
@@ -28,6 +30,8 @@ export function Bandeja({
   userName,
   sessionId,
   personagemId,
+  onMensagemCriada,
+  mensagemExternaCriada,
   mensagensIniciais,
 }: Props) {
   const bandejaRef = useRef<HTMLDivElement>(null);
@@ -187,9 +191,15 @@ export function Bandeja({
     return "fas fa-chevron-up";
   }
 
-  const onMensagemCriada = useCallback((msg: MensagemSerializada) => {
+  const onMensagemCriadaLocal = useCallback((msg: MensagemSerializada) => {
     chatRef.current?.appendLocal(msg);
-  }, []);
+    onMensagemCriada?.(msg);
+  }, [onMensagemCriada]);
+
+  useEffect(() => {
+    if (!mensagemExternaCriada) return;
+    chatRef.current?.appendLocal(mensagemExternaCriada);
+  }, [mensagemExternaCriada]);
 
   return (
     <div ref={bandejaRef} className={className} style={style} id="bandeja">
@@ -234,7 +244,7 @@ export function Bandeja({
             userName={userName}
             sessionId={sessionId}
             personagemId={personagemId || null}
-            onMensagemCriada={onMensagemCriada}
+            onMensagemCriada={onMensagemCriadaLocal}
           />
         </div>
 
@@ -247,6 +257,7 @@ export function Bandeja({
             userId={userId}
             userName={userName}
             sessionId={sessionId}
+            personagemId={personagemId || null}
             mensagensIniciais={mensagensIniciais}
           />
         </div>

--- a/components/bandeja/painel-chat.tsx
+++ b/components/bandeja/painel-chat.tsx
@@ -9,10 +9,12 @@ import {
   useState,
 } from "react";
 import Swal from "sweetalert2";
+import { rolarDados } from "@/lib/dice";
 import { createClient } from "@/lib/supabase/client";
 import {
   enviarMensagemTexto,
   limparMensagens,
+  registrarRolagem,
   listarMensagens,
 } from "./actions";
 import type { MensagemSerializada } from "@/lib/mensagens";
@@ -27,13 +29,14 @@ type Props = {
   userId: string;
   userName: string;
   sessionId: string;
+  personagemId: string | null;
   // Mensagens pré-carregadas no SSR. PainelChat usa como estado inicial,
   // evitando o round-trip de listarMensagens ao abrir a aba.
   mensagensIniciais: MensagemSerializada[];
 };
 
 export const PainelChat = forwardRef<PainelChatHandle, Props>(function PainelChat(
-  { userId, userName, sessionId, mensagensIniciais },
+  { userId, userName, sessionId, personagemId, mensagensIniciais },
   ref,
 ) {
   const [mensagens, setMensagens] = useState<MensagemSerializada[]>(mensagensIniciais);
@@ -152,7 +155,18 @@ export const PainelChat = forwardRef<PainelChatHandle, Props>(function PainelCha
             Nenhuma mensagem ainda...
           </p>
         ) : (
-          mensagens.map((m) => <MensagemView key={m.id} msg={m} meuUid={userId} />)
+          mensagens.map((m) => (
+            <MensagemView
+              key={m.id}
+              msg={m}
+              mensagens={mensagens}
+              meuUid={userId}
+              userName={userName}
+              sessionId={sessionId}
+              personagemId={personagemId}
+              onMensagemAtualizada={appendLocal}
+            />
+          ))
         )}
       </div>
       <div className="chat-input-row">
@@ -178,10 +192,20 @@ export const PainelChat = forwardRef<PainelChatHandle, Props>(function PainelCha
 
 function MensagemView({
   msg,
+  mensagens,
   meuUid,
+  userName,
+  sessionId,
+  personagemId,
+  onMensagemAtualizada,
 }: {
   msg: MensagemSerializada;
+  mensagens: MensagemSerializada[];
   meuUid: string;
+  userName: string;
+  sessionId: string;
+  personagemId: string | null;
+  onMensagemAtualizada: (msg: MensagemSerializada) => void;
 }) {
   const hora = new Date(msg.timestamp).toLocaleTimeString("pt-BR", {
     hour: "2-digit",
@@ -194,10 +218,18 @@ function MensagemView({
       | {
           rolls?: Array<{ faces: number; sinal: 1 | -1; resultado: number }>;
           nomePreset?: string | null;
+          tipoTeste?: boolean | null;
+          pericia?: string | null;
+          cd?: number | null;
+          sucesso?: boolean | null;
+          privacidadeResultado?: boolean | null;
         }
       | Array<{ faces: number; sinal: 1 | -1; resultado: number }>;
     const arr = Array.isArray(raw) ? raw : raw.rolls || [];
     const presetLabel = !Array.isArray(raw) ? raw.nomePreset || null : null;
+    const testeLabel = !Array.isArray(raw) ? raw.pericia || null : null;
+    const sucesso = !Array.isArray(raw) ? raw.sucesso ?? null : null;
+    const privacidadeResultado = !Array.isArray(raw) ? raw.privacidadeResultado ?? true : true;
 
     let stringDados = "";
     arr.forEach((d, i) => {
@@ -214,29 +246,207 @@ function MensagemView({
     }
 
     return (
-      <div className="chat-message roll-message">
+      <div className={"chat-message roll-message" + (sucesso === true ? " success" : sucesso === false ? " fail" : "") }>
         <div className="roll-header">
           {hora} <strong>{nome}</strong>
         </div>
+        {testeLabel && (
+          <div className="roll-preset-tag">
+            <i className="fas fa-dice-d20" /> {testeLabel}
+          </div>
+        )}
         {presetLabel && (
           <div className="roll-preset-tag">
             <i className="fas fa-bookmark" /> {presetLabel}
           </div>
         )}
         <div className="roll-box">
-          <div className="roll-total">{msg.total}</div>
+          <div className="roll-total">{privacidadeResultado ? msg.total : "?"}</div>
           <div
             className="roll-details"
-            dangerouslySetInnerHTML={{ __html: `[${msg.total}] = ${stringDados}` }}
+            dangerouslySetInnerHTML={{ __html: privacidadeResultado ? `[${msg.total}] = ${stringDados}` : "Resultado oculto" }}
           />
         </div>
       </div>
     );
   }
 
+  if (msg.tipo === "teste" && msg.detalhes) {
+    return (
+      <TesteMensagemView
+        msg={msg}
+        mensagens={mensagens}
+        meuUid={meuUid}
+        userName={userName}
+        sessionId={sessionId}
+        personagemId={personagemId}
+        onMensagemAtualizada={onMensagemAtualizada}
+      />
+    );
+  }
+
   return (
     <div className="chat-message">
       {hora} <strong>{nome}</strong>: {msg.mensagem}
+    </div>
+  );
+}
+
+function TesteMensagemView({
+  msg,
+  mensagens,
+  meuUid,
+  userName,
+  sessionId,
+  personagemId,
+  onMensagemAtualizada,
+}: {
+  msg: MensagemSerializada;
+  mensagens: MensagemSerializada[];
+  meuUid: string;
+  userName: string;
+  sessionId: string;
+  personagemId: string | null;
+  onMensagemAtualizada: (msg: MensagemSerializada) => void;
+}) {
+  const hora = new Date(msg.timestamp).toLocaleTimeString("pt-BR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const nome = msg.uid === meuUid ? "Você" : msg.nome;
+  const detalhes = msg.detalhes as {
+    pericia?: string | null;
+    cd?: number | null;
+    privacidadeCd?: boolean;
+    privacidadeResultado?: boolean;
+    alvos?: string[] | "TODOS";
+    alvosNomes?: string[];
+    statusPorNome?: Record<string, string>;
+  };
+  const [modificador, setModificador] = useState(0);
+  const [rolando, setRolando] = useState(false);
+  const [selecionado, setSelecionado] = useState("");
+
+  const isNarrador = !personagemId;
+  const isAlvo =
+    !isNarrador &&
+    (detalhes.alvos === "TODOS" ||
+      (Array.isArray(detalhes.alvos) && personagemId && detalhes.alvos.includes(personagemId)));
+  const jaRolou = mensagens.some(
+    (m) =>
+      m.tipo === "rolagem" &&
+      m.uid === meuUid &&
+      Boolean(
+        (m.detalhes as { solicitacaoTesteId?: string | null } | null)?.solicitacaoTesteId === msg.id,
+      ),
+  );
+  const envolvidos =
+    detalhes.alvos === "TODOS"
+      ? detalhes.alvosNomes || []
+      : detalhes.alvosNomes || [];
+
+  const selecionadoAtual = envolvidos.includes(selecionado) ? selecionado : envolvidos[0] || "";
+
+  function statusPorNome(nome: string): string {
+    return detalhes.statusPorNome?.[nome] || "Aguardando resultado";
+  }
+
+  async function resolverTeste() {
+    if (rolando || !isAlvo || jaRolou) return;
+    setRolando(true);
+    try {
+      const resultado = rolarDados([{ faces: 20, sinal: 1 }], modificador);
+      const sucesso = typeof detalhes.cd === "number" ? resultado.total >= detalhes.cd : null;
+      const mensagem = await registrarRolagem(
+        sessionId,
+        userName,
+        {
+          total: resultado.total,
+          detalhes: resultado.detalhes,
+          modificador,
+          nomePreset: null,
+          tipoTeste: true,
+          pericia: detalhes.pericia || null,
+          cd: detalhes.cd ?? null,
+          sucesso,
+          privacidadeResultado: detalhes.privacidadeResultado ?? true,
+          solicitacaoTesteId: msg.id,
+          alvoNome: userName,
+        },
+        personagemId,
+        personagemId ? `[${resultado.total}] = 1d20 ${modificador >= 0 ? "+" : "-"} ${Math.abs(modificador)}` : null,
+      );
+      onMensagemAtualizada(mensagem);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setRolando(false);
+    }
+  }
+
+  return (
+    <div className="chat-message teste-message">
+      <div className="roll-header">
+        {hora} <strong>{nome}</strong>
+      </div>
+      <div className="teste-box">
+        <div className="teste-titulo">
+          <i className="fas fa-dice-d20" />
+          <span>{detalhes.pericia || "Teste"}</span>
+        </div>
+        {isNarrador ? (
+          <>
+            <div className="teste-notificacao">
+              Solicitação de teste enviada para os jogadores envolvidos.
+            </div>
+            <label className="teste-mod-label">
+              Situação do teste
+              <select
+                className="teste-select"
+                value={selecionadoAtual}
+                onChange={(e) => setSelecionado(e.target.value)}
+                disabled={envolvidos.length === 0}
+              >
+                {envolvidos.length === 0 ? (
+                  <option value="">Sem envolvidos</option>
+                ) : (
+                  envolvidos.map((nome) => (
+                    <option key={nome} value={nome}>
+                      {nome} - {statusPorNome(nome)}
+                    </option>
+                  ))
+                )}
+              </select>
+            </label>
+          </>
+        ) : isAlvo ? (
+          <>
+            {typeof detalhes.cd === "number" && detalhes.privacidadeCd !== false && (
+              <div className="teste-cd">CD {detalhes.cd}</div>
+            )}
+            <label className="teste-mod-label">
+              Modificador manual
+              <input
+                type="number"
+                value={modificador}
+                onChange={(e) => setModificador(Number(e.target.value) || 0)}
+              />
+            </label>
+            <button
+              type="button"
+              className="teste-btn"
+              onClick={resolverTeste}
+              disabled={rolando || jaRolou}
+            >
+              {rolando ? "Rolando..." : jaRolou ? "Teste realizado" : "Rolar teste"}
+            </button>
+          </>
+        ) : (
+          <div style={{ color: "var(--text-sec)", fontSize: "0.9rem", fontWeight: 700 }}>
+            Você não é alvo deste teste.
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/bandeja/painel-chat.tsx
+++ b/components/bandeja/painel-chat.tsx
@@ -250,14 +250,18 @@ function MensagemView({
         <div className="roll-header">
           {hora} <strong>{nome}</strong>
         </div>
-        {testeLabel && (
-          <div className="roll-preset-tag">
-            <i className="fas fa-dice-d20" /> {testeLabel}
-          </div>
-        )}
-        {presetLabel && (
-          <div className="roll-preset-tag">
-            <i className="fas fa-bookmark" /> {presetLabel}
+        {(testeLabel || presetLabel) && (
+          <div className="roll-tags">
+            {testeLabel && (
+              <div className="teste-pericia-tag">
+                <i className="fas fa-dice-d20" /> <span>{testeLabel}</span>
+              </div>
+            )}
+            {presetLabel && (
+              <div className="teste-pericia-tag">
+                <i className="fas fa-bookmark" /> <span>{presetLabel}</span>
+              </div>
+            )}
           </div>
         )}
         <div className="roll-box">
@@ -325,7 +329,7 @@ function TesteMensagemView({
   };
   const [modificador, setModificador] = useState(0);
   const [rolando, setRolando] = useState(false);
-  const [selecionado, setSelecionado] = useState("");
+  const [acompanhamentoAberto, setAcompanhamentoAberto] = useState(false);
 
   const isNarrador = !personagemId;
   const isAlvo =
@@ -345,7 +349,9 @@ function TesteMensagemView({
       ? detalhes.alvosNomes || []
       : detalhes.alvosNomes || [];
 
-  const selecionadoAtual = envolvidos.includes(selecionado) ? selecionado : envolvidos[0] || "";
+  if (!isNarrador && !isAlvo) {
+    return null;
+  }
 
   function statusPorNome(nome: string): string {
     return detalhes.statusPorNome?.[nome] || "Aguardando resultado";
@@ -390,62 +396,71 @@ function TesteMensagemView({
         {hora} <strong>{nome}</strong>
       </div>
       <div className="teste-box">
-        <div className="teste-titulo">
+        <div className="teste-pericia-tag">
           <i className="fas fa-dice-d20" />
           <span>{detalhes.pericia || "Teste"}</span>
         </div>
         {isNarrador ? (
           <>
-            <div className="teste-notificacao">
-              Solicitação de teste enviada para os jogadores envolvidos.
+            <div className="teste-notificacao teste-notificacao-narrador">
+              <div className="teste-notificacao-topo">
+                <i className="fas fa-bell" />
+                <span>Solicitação enviada a jogadores envolvidos.</span>
+              </div>
+              <div className="teste-notificacao-subtexto">
+                Acompanhe abaixo a situação de cada personagem.
+              </div>
             </div>
-            <label className="teste-mod-label">
-              Situação do teste
-              <select
-                className="teste-select"
-                value={selecionadoAtual}
-                onChange={(e) => setSelecionado(e.target.value)}
-                disabled={envolvidos.length === 0}
-              >
+            <button
+              type="button"
+              className={"teste-acompanhamento-toggle" + (acompanhamentoAberto ? " open" : "")}
+              onClick={() => setAcompanhamentoAberto((aberto) => !aberto)}
+            >
+              <span>Acompanhamento</span>
+              <i className="fas fa-chevron-down teste-dropdown-icone" />
+            </button>
+            <div className={"teste-acompanhamento" + (acompanhamentoAberto ? " open" : "") }>
+              <div className="teste-acompanhamento-lista">
                 {envolvidos.length === 0 ? (
-                  <option value="">Sem envolvidos</option>
+                  <div className="teste-acompanhamento-item vazia">Sem envolvidos</div>
                 ) : (
                   envolvidos.map((nome) => (
-                    <option key={nome} value={nome}>
-                      {nome} - {statusPorNome(nome)}
-                    </option>
+                    <div key={nome} className="teste-acompanhamento-item">
+                      <span className="nome">{nome}</span>
+                      <span className="status">{statusPorNome(nome)}</span>
+                    </div>
                   ))
                 )}
-              </select>
-            </label>
+              </div>
+            </div>
           </>
         ) : isAlvo ? (
           <>
             {typeof detalhes.cd === "number" && detalhes.privacidadeCd !== false && (
-              <div className="teste-cd">CD {detalhes.cd}</div>
+              <div className="teste-meta-linha">
+                <div className="teste-cd">CD {detalhes.cd}</div>
+              </div>
             )}
-            <label className="teste-mod-label">
-              Modificador manual
-              <input
-                type="number"
-                value={modificador}
-                onChange={(e) => setModificador(Number(e.target.value) || 0)}
-              />
-            </label>
+            {!jaRolou && (
+              <label className="teste-status-label">
+                Modificador manual
+                <input
+                  type="number"
+                  value={modificador}
+                  onChange={(e) => setModificador(Number(e.target.value) || 0)}
+                />
+              </label>
+            )}
             <button
               type="button"
-              className="teste-btn"
+              className={"teste-btn" + (jaRolou ? " teste-btn-done" : "")}
               onClick={resolverTeste}
               disabled={rolando || jaRolou}
             >
               {rolando ? "Rolando..." : jaRolou ? "Teste realizado" : "Rolar teste"}
             </button>
           </>
-        ) : (
-          <div style={{ color: "var(--text-sec)", fontSize: "0.9rem", fontWeight: 700 }}>
-            Você não é alvo deste teste.
-          </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/components/bandeja/painel-chat.tsx
+++ b/components/bandeja/painel-chat.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import Swal from "sweetalert2";
-import { rolarDados } from "@/lib/dice";
+import { formatarResultadoRolagemHtml, rolarDados } from "@/lib/dice";
 import { createClient } from "@/lib/supabase/client";
 import {
   enviarMensagemTexto,
@@ -216,7 +216,16 @@ function MensagemView({
   if (msg.tipo === "rolagem" && msg.detalhes) {
     const raw = msg.detalhes as
       | {
+          kind?: "rolagem" | "lote";
           rolls?: Array<{ faces: number; sinal: 1 | -1; resultado: number }>;
+          execucoes?: Array<{
+            total: number;
+            modificador: number;
+            modo?: "normal" | "vantagem" | "desvantagem";
+            rolls?: Array<{ faces: number; sinal: 1 | -1; resultado: number }>;
+          }>;
+          quantidade?: number;
+          modo?: "normal" | "vantagem" | "desvantagem";
           nomePreset?: string | null;
           tipoTeste?: boolean | null;
           pericia?: string | null;
@@ -225,32 +234,31 @@ function MensagemView({
           privacidadeResultado?: boolean | null;
         }
       | Array<{ faces: number; sinal: 1 | -1; resultado: number }>;
+    const ehLote = !Array.isArray(raw) && raw.kind === "lote" && Array.isArray(raw.execucoes);
     const arr = Array.isArray(raw) ? raw : raw.rolls || [];
+    const execucoes = ehLote ? raw.execucoes || [] : [];
+    const quantidade = ehLote ? raw.quantidade || execucoes.length : 0;
+    const modo = !Array.isArray(raw) ? raw.modo || "normal" : "normal";
     const presetLabel = !Array.isArray(raw) ? raw.nomePreset || null : null;
     const testeLabel = !Array.isArray(raw) ? raw.pericia || null : null;
     const sucesso = !Array.isArray(raw) ? raw.sucesso ?? null : null;
     const privacidadeResultado = !Array.isArray(raw) ? raw.privacidadeResultado ?? true : true;
-
-    let stringDados = "";
-    arr.forEach((d, i) => {
-      const op =
-        i === 0 ? (d.sinal === -1 ? "- " : "") : d.sinal === 1 ? " + " : " - ";
-      let res = `${d.resultado}`;
-      if (d.resultado === 1) res = `<span class="crit-fail">${d.resultado}</span>`;
-      else if (d.resultado === d.faces)
-        res = `<span class="crit-success">${d.resultado}</span>`;
-      stringDados += `${op}(${res}) 1d${d.faces}`;
-    });
-    if (msg.modificador && msg.modificador !== 0) {
-      stringDados += ` ${msg.modificador >= 0 ? "+" : "-"} ${Math.abs(msg.modificador)}`;
-    }
+    const resultadoOculto = !privacidadeResultado;
+    const totalDisplay = resultadoOculto ? "?" : ehLote ? `${quantidade}x` : String(msg.total ?? "?");
+    const detalhesUnitarios = resultadoOculto
+      ? "Resultado oculto"
+      : formatarResultadoRolagemHtml({
+          detalhes: arr,
+          modificador: msg.modificador || 0,
+        });
+    const modoLabel = modo === "vantagem" ? "Vantagem" : modo === "desvantagem" ? "Desvantagem" : "Normal";
 
     return (
       <div className={"chat-message roll-message" + (sucesso === true ? " success" : sucesso === false ? " fail" : "") }>
         <div className="roll-header">
           {hora} <strong>{nome}</strong>
         </div>
-        {(testeLabel || presetLabel) && (
+        {(testeLabel || presetLabel || ehLote || modo !== "normal") && (
           <div className="roll-tags">
             {testeLabel && (
               <div className="teste-pericia-tag">
@@ -262,14 +270,45 @@ function MensagemView({
                 <i className="fas fa-bookmark" /> <span>{presetLabel}</span>
               </div>
             )}
+            {modo !== "normal" && (
+              <div className="roll-mode-tag">
+                <i className="fas fa-clone" /> <span>{modoLabel}</span>
+              </div>
+            )}
+            {ehLote && (
+              <div className="roll-mode-tag">
+                <i className="fas fa-layer-group" /> <span>{quantidade}x</span>
+              </div>
+            )}
           </div>
         )}
         <div className="roll-box">
-          <div className="roll-total">{privacidadeResultado ? msg.total : "?"}</div>
-          <div
-            className="roll-details"
-            dangerouslySetInnerHTML={{ __html: privacidadeResultado ? `[${msg.total}] = ${stringDados}` : "Resultado oculto" }}
-          />
+          <div className="roll-total">{totalDisplay}</div>
+          {ehLote ? (
+            resultadoOculto ? (
+              <div className="roll-details">Resultado oculto</div>
+            ) : (
+              <div className="roll-batch-list">
+                {execucoes.map((execucao, indice) => (
+                  <div key={indice} className="roll-batch-row">
+                    <span className="roll-batch-index">#{indice + 1}</span>
+                    <span className="roll-batch-total">[{execucao.total}]</span>
+                    <span
+                      className="roll-batch-formula"
+                      dangerouslySetInnerHTML={{
+                        __html: `= ${formatarResultadoRolagemHtml({
+                          detalhes: execucao.rolls || [],
+                          modificador: execucao.modificador,
+                        })}`,
+                      }}
+                    />
+                  </div>
+                ))}
+              </div>
+            )
+          ) : (
+            <div className="roll-details" dangerouslySetInnerHTML={{ __html: detalhesUnitarios }} />
+          )}
         </div>
       </div>
     );
@@ -367,9 +406,11 @@ function TesteMensagemView({
         sessionId,
         userName,
         {
+          tipo: "rolagem",
           total: resultado.total,
           detalhes: resultado.detalhes,
           modificador,
+          modo: "normal",
           nomePreset: null,
           tipoTeste: true,
           pericia: detalhes.pericia || null,

--- a/components/bandeja/painel-rolador.tsx
+++ b/components/bandeja/painel-rolador.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Swal from "sweetalert2";
 import {
   type Dado,
@@ -51,9 +51,13 @@ export function PainelRolador({
   const [modoGravacao, setModoGravacao] = useState(false);
   const [resultado, setResultado] = useState<Resultado>({ tipo: "preview" });
   const [presetsAbertos, setPresetsAbertos] = useState(false);
-  const [presets, setPresets] = useState<Preset[]>(() => getPresets(userId));
+  const [presets, setPresets] = useState<Preset[]>([]);
   const [pedindoNome, setPedindoNome] = useState(false);
   const [nomePresetTmp, setNomePresetTmp] = useState("");
+
+  useEffect(() => {
+    setPresets(getPresets(userId));
+  }, [userId]);
 
   const modificador = Number(modificadorTexto || 0);
   const quantidade = Number(quantidadeTexto || 1);
@@ -115,6 +119,14 @@ export function PainelRolador({
     }
     const valor = Math.max(1, Math.trunc(Number(quantidadeTexto) || 1));
     setQuantidadeTexto(String(valor));
+  }
+
+  function desfocarCampoAtivo(event: React.MouseEvent<HTMLDivElement>) {
+    const alvo = event.target as HTMLElement | null;
+    if (!alvo) return;
+    if (alvo.closest("input") || alvo.closest("button")) return;
+    const ativo = document.activeElement;
+    if (ativo instanceof HTMLElement) ativo.blur();
   }
 
   function alternarModoRolagem(modo: Exclude<ModoRolagem, "normal">) {
@@ -231,7 +243,13 @@ export function PainelRolador({
   function salvarPresetComNome() {
     const nv = nomePresetTmp.trim();
     if (!nv) return;
-    addPreset(userId, { nome: nv, dados, modificador });
+    addPreset(userId, {
+      nome: nv,
+      dados,
+      modificador,
+      modoRolagem,
+      quantidade: quantidadeValida,
+    });
     setPresets(getPresets(userId));
     setPedindoNome(false);
     setNomePresetTmp("");
@@ -265,7 +283,7 @@ export function PainelRolador({
 
   async function executarPreset(p: Preset) {
     if (modoGravacao) cancelarGravacao();
-    executarRolagem(p.dados, p.modificador, p.nome, quantidadeValida, modoRolagem);
+    executarRolagem(p.dados, p.modificador, p.nome, p.quantidade, p.modoRolagem);
   }
 
   async function apagarPreset(p: Preset) {
@@ -307,7 +325,7 @@ export function PainelRolador({
         ))}
       </div>
 
-      <div className="tray-footer roll-footer-row">
+      <div className="tray-footer roll-footer-row" onMouseDownCapture={desfocarCampoAtivo}>
         <label className="roll-footer-field">
           <span>Repetições</span>
           <input
@@ -435,7 +453,11 @@ export function PainelRolador({
                     onClick={() => executarPreset(p)}
                   >
                     <span className="preset-card-name">{p.nome}</span>
-                    <span className="preset-card-formula">{formulaTexto(p.dados, p.modificador)}</span>
+                    <span className="preset-card-formula">
+                      {formulaTexto(p.dados, p.modificador)}
+                      {p.quantidade > 1 ? ` ×${p.quantidade}` : ""}
+                      {p.modoRolagem !== "normal" ? ` · ${rotuloModo(p.modoRolagem)}` : ""}
+                    </span>
                     <button
                       type="button"
                       className="preset-card-del"

--- a/components/bandeja/painel-rolador.tsx
+++ b/components/bandeja/painel-rolador.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import Swal from "sweetalert2";
-import { type Dado, formulaTexto, rolarDados } from "@/lib/dice";
+import {
+  type Dado,
+  formulaTexto,
+  formatarResultadoRolagemHtml,
+  rolarDados,
+  rolarLote,
+  type ModoRolagem,
+} from "@/lib/dice";
 import { addPreset, getPresets, removePreset, type Preset } from "@/lib/presets";
 import { registrarRolagem } from "./actions";
 import type { MensagemSerializada } from "@/lib/mensagens";
@@ -21,7 +28,13 @@ const FACES = [4, 6, 8, 10, 12, 20, 100] as const;
 // última rolagem (mantido até o usuário mexer em qualquer input).
 type Resultado =
   | { tipo: "preview" }
-  | { tipo: "rolado"; total: number; detalhesHtml: string };
+  | { tipo: "rolado"; total: string; detalhesHtml: string };
+
+function rotuloModo(modo: ModoRolagem): string {
+  if (modo === "vantagem") return "Vantagem";
+  if (modo === "desvantagem") return "Desvantagem";
+  return "Normal";
+}
 
 export function PainelRolador({
   userId,
@@ -31,20 +44,22 @@ export function PainelRolador({
   onMensagemCriada,
 }: Props) {
   const [dados, setDados] = useState<Dado[]>([]);
-  const [modificador, setModificador] = useState(0);
+  const [modificadorTexto, setModificadorTexto] = useState("0");
   const [negativo, setNegativo] = useState(false);
+  const [modoRolagem, setModoRolagem] = useState<ModoRolagem>("normal");
+  const [quantidadeTexto, setQuantidadeTexto] = useState("1");
   const [modoGravacao, setModoGravacao] = useState(false);
   const [resultado, setResultado] = useState<Resultado>({ tipo: "preview" });
   const [presetsAbertos, setPresetsAbertos] = useState(false);
-  const [presets, setPresets] = useState<Preset[]>([]);
+  const [presets, setPresets] = useState<Preset[]>(() => getPresets(userId));
   const [pedindoNome, setPedindoNome] = useState(false);
   const [nomePresetTmp, setNomePresetTmp] = useState("");
 
-  useEffect(() => {
-    setPresets(getPresets(userId));
-  }, [userId]);
-
+  const modificador = Number(modificadorTexto || 0);
+  const quantidade = Number(quantidadeTexto || 1);
   const vazio = dados.length === 0 && modificador === 0;
+  const quantidadeValida = Math.max(1, Math.trunc(quantidade || 0));
+  const loteAtivo = quantidadeValida > 1;
 
   const preview = useMemo(() => {
     if (vazio) {
@@ -52,11 +67,18 @@ export function PainelRolador({
         total: "--",
         detalhes: modoGravacao
           ? "Monte a rolagem do preset..."
-          : "Selecione dados...",
+          : loteAtivo
+            ? `Lote ${quantidadeValida}x · ${rotuloModo(modoRolagem).toLowerCase()}`
+            : "Selecione dados...",
       };
     }
-    return { total: "??", detalhes: formulaTexto(dados, modificador) };
-  }, [vazio, dados, modificador, modoGravacao]);
+    return {
+      total: "??",
+      detalhes: `${formulaTexto(dados, modificador)}${loteAtivo ? ` ×${quantidadeValida}` : ""}${
+        modoRolagem !== "normal" ? ` · ${rotuloModo(modoRolagem)}` : ""
+      }`,
+    };
+  }, [vazio, dados, modificador, modoGravacao, loteAtivo, quantidadeValida, modoRolagem]);
 
   const display =
     resultado.tipo === "rolado"
@@ -68,58 +90,123 @@ export function PainelRolador({
     setResultado({ tipo: "preview" });
   }
 
-  function mudarMod(v: number) {
-    setModificador(v);
+  function mudarMod(v: string) {
+    setModificadorTexto(v);
+    setResultado({ tipo: "preview" });
+  }
+
+  function mudarQuantidade(v: string) {
+    setQuantidadeTexto(v);
+    setResultado({ tipo: "preview" });
+  }
+
+  function normalizarModificador() {
+    if (modificadorTexto.trim() === "") {
+      setModificadorTexto("0");
+      return;
+    }
+    setModificadorTexto(String(Number(modificadorTexto) || 0));
+  }
+
+  function normalizarQuantidade() {
+    if (quantidadeTexto.trim() === "") {
+      setQuantidadeTexto("1");
+      return;
+    }
+    const valor = Math.max(1, Math.trunc(Number(quantidadeTexto) || 1));
+    setQuantidadeTexto(String(valor));
+  }
+
+  function alternarModoRolagem(modo: Exclude<ModoRolagem, "normal">) {
+    setModoRolagem((atual) => (atual === modo ? "normal" : modo));
     setResultado({ tipo: "preview" });
   }
 
   function limpar() {
     setDados([]);
-    setModificador(0);
+    setModificadorTexto("0");
     setNegativo(false);
+    setModoRolagem("normal");
+    setQuantidadeTexto("1");
     setResultado({ tipo: "preview" });
   }
 
-  function executarRolagem(dadosUsar: Dado[], modUsar: number, nomePreset: string | null) {
+  function executarRolagem(
+    dadosUsar: Dado[],
+    modUsar: number,
+    nomePreset: string | null,
+    quantidadeUsar: number,
+    modoUsar: ModoRolagem,
+  ) {
     if (dadosUsar.length === 0 && modUsar === 0) return;
-    const r = rolarDados(dadosUsar, modUsar);
+    const prefixo = nomePreset ? `[${nomePreset}] ` : "";
 
-    // Formata detalhes (com crit-success/fail)
-    let stringFinal = "";
-    r.detalhes.forEach((d, i) => {
-      const op =
-        i === 0 ? (d.sinal === -1 ? "- " : "") : d.sinal === 1 ? " + " : " - ";
-      let res = `${d.resultado}`;
-      if (d.resultado === 1) res = `<span class="crit-fail">${d.resultado}</span>`;
-      else if (d.resultado === d.faces)
-        res = `<span class="crit-success">${d.resultado}</span>`;
-      stringFinal += `${op}(${res}) 1d${d.faces}`;
-    });
-    if (modUsar !== 0) {
-      stringFinal += ` ${modUsar >= 0 ? "+" : "-"} ${Math.abs(modUsar)}`;
+    if (quantidadeUsar > 1) {
+      const lote = rolarLote(dadosUsar, modUsar, quantidadeUsar, modoUsar);
+      const linhas = lote.execucoes
+        .map(
+          (execucao, indice) =>
+            `<div class="roll-batch-row"><span class="roll-batch-index">#${indice + 1}</span><span class="roll-batch-total">[${execucao.total}]</span><span class="roll-batch-formula">= ${formatarResultadoRolagemHtml(execucao)}</span></div>`,
+        )
+        .join("");
+      const resumo = `${quantidadeUsar}x ${rotuloModo(modoUsar).toLowerCase()}`;
+
+      setResultado({
+        tipo: "rolado",
+        total: `${quantidadeUsar}x`,
+        detalhesHtml: `[${resumo}] ${formulaTexto(dadosUsar, modUsar)}${modUsar !== 0 ? ` ${modUsar >= 0 ? "+" : "-"} ${Math.abs(modUsar)}` : ""}<div class="roll-batch-list">${linhas}</div>`,
+      });
+
+      const ultimaRolagemTexto = personagemId ? `${prefixo}[${resumo}] ${formulaTexto(dadosUsar, modUsar)}` : null;
+
+      registrarRolagem(
+        sessionId,
+        userName,
+        {
+          tipo: "lote",
+          total: null,
+          quantidade: lote.quantidade,
+          modificador: modUsar,
+          modo: modoUsar,
+          execucoes: lote.execucoes.map((execucao) => ({
+            total: execucao.total,
+            modificador: execucao.modificador,
+            modo: execucao.modo,
+            detalhes: execucao.detalhes,
+          })),
+          nomePreset: nomePreset || null,
+        },
+        personagemId,
+        ultimaRolagemTexto,
+      )
+        .then((msg) => onMensagemCriada(msg))
+        .catch((err) => console.error(err));
+      return;
     }
+
+    const r = rolarDados(dadosUsar, modUsar, modoUsar);
+    const stringFinal = formatarResultadoRolagemHtml(r);
 
     setResultado({
       tipo: "rolado",
-      total: r.total,
+      total: String(r.total),
       detalhesHtml: `[${r.total}] = ${stringFinal}`,
     });
 
     // Uma única chamada: registra a mensagem no chat E salva ultimaRolagem no
     // personagem (em paralelo no servidor). Retorna a mensagem pra append local.
     const textoLimpo = stringFinal.replace(/<[^>]*>?/gm, "");
-    const prefixo = nomePreset ? `[${nomePreset}] ` : "";
-    const ultimaRolagemTexto = personagemId
-      ? `${prefixo}[${r.total}] = ${textoLimpo}`
-      : null;
+    const ultimaRolagemTexto = personagemId ? `${prefixo}[${r.total}] = ${textoLimpo}` : null;
 
     registrarRolagem(
       sessionId,
       userName,
       {
+        tipo: "rolagem",
         total: r.total,
         detalhes: r.detalhes,
         modificador: modUsar,
+        modo: modoUsar,
         nomePreset: nomePreset || null,
       },
       personagemId,
@@ -136,7 +223,7 @@ export function PainelRolador({
       setNomePresetTmp("");
       return;
     }
-    executarRolagem(dados, modificador, null);
+    executarRolagem(dados, modificador, null, quantidadeValida, modoRolagem);
     // Mantém modificador, limpa só os dados (igual legacy)
     setDados([]);
   }
@@ -150,7 +237,9 @@ export function PainelRolador({
     setNomePresetTmp("");
     setModoGravacao(false);
     setDados([]);
-    setModificador(0);
+    setModificadorTexto("0");
+    setModoRolagem("normal");
+    setQuantidadeTexto("1");
     setResultado({ tipo: "preview" });
     setPresetsAbertos(true);
   }
@@ -158,21 +247,25 @@ export function PainelRolador({
   function entrarGravacao() {
     setModoGravacao(true);
     setDados([]);
-    setModificador(0);
+    setModificadorTexto("0");
     setNegativo(false);
+    setModoRolagem("normal");
+    setQuantidadeTexto("1");
     setResultado({ tipo: "preview" });
   }
 
   function cancelarGravacao() {
     setModoGravacao(false);
     setDados([]);
-    setModificador(0);
+    setModificadorTexto("0");
+    setModoRolagem("normal");
+    setQuantidadeTexto("1");
     setResultado({ tipo: "preview" });
   }
 
   async function executarPreset(p: Preset) {
     if (modoGravacao) cancelarGravacao();
-    executarRolagem(p.dados, p.modificador, p.nome);
+    executarRolagem(p.dados, p.modificador, p.nome, quantidadeValida, modoRolagem);
   }
 
   async function apagarPreset(p: Preset) {
@@ -214,19 +307,63 @@ export function PainelRolador({
         ))}
       </div>
 
-      <div className="tray-footer">
-        <div style={{ flex: 1 }}>
-          <label style={{ fontSize: "0.7rem", color: "var(--text-sec)" }}>Modificador</label>
+      <div className="tray-footer roll-footer-row">
+        <label className="roll-footer-field">
+          <span>Repetições</span>
           <input
-            type="number"
-            value={modificador}
-            onChange={(e) => mudarMod(Number(e.target.value) || 0)}
-            placeholder="+0"
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={quantidadeTexto}
+            onFocus={() => {
+              if (quantidadeTexto === "0") setQuantidadeTexto("");
+            }}
+            onChange={(e) => mudarQuantidade(e.target.value)}
+            onBlur={normalizarQuantidade}
           />
-        </div>
+        </label>
+
+        <span className="roll-footer-separator">x</span>
+
+        <label className="roll-footer-field roll-footer-mod">
+          <span>Modificador</span>
+          <input
+            type="text"
+            inputMode="numeric"
+            pattern="-?[0-9]*"
+            value={modificadorTexto}
+            onFocus={() => {
+              if (modificadorTexto === "0") setModificadorTexto("");
+            }}
+            onChange={(e) => mudarMod(e.target.value)}
+            placeholder="+0"
+            onBlur={normalizarModificador}
+          />
+        </label>
+
         <button type="button" className="clear-btn" title="Limpar" onClick={limpar}>
           <i className="fas fa-trash" />
         </button>
+      </div>
+
+      <div className="roll-settings">
+        <div className="roll-mode-switch" role="group" aria-label="Modo de rolagem">
+          {([
+            ["vantagem", "Vant.", "fa-clone", "vantagem"],
+            ["desvantagem", "Desv.", "fa-clone", "desvantagem"],
+          ] as const).map(([modo, texto, icone, tipo]) => (
+            <button
+              key={modo}
+              type="button"
+              className={"roll-toggle-btn " + tipo + (modoRolagem === modo ? " active" : "")}
+              onClick={() => alternarModoRolagem(modo)}
+              aria-pressed={modoRolagem === modo}
+            >
+              <i className={`fas ${icone}`} />
+              <span>{texto}</span>
+            </button>
+          ))}
+        </div>
       </div>
 
       <button
@@ -235,7 +372,7 @@ export function PainelRolador({
         onClick={clicarRolar}
         disabled={vazio}
       >
-        {modoGravacao ? "SALVAR PRESET" : "ROLAR!"}
+        {modoGravacao ? "SALVAR PRESET" : loteAtivo ? `ROLAR X${quantidadeValida}` : "ROLAR!"}
       </button>
 
       <div className="tray-result-box">

--- a/lib/crop-image.ts
+++ b/lib/crop-image.ts
@@ -20,15 +20,30 @@ function carregarImagem(src: string): Promise<HTMLImageElement> {
 export async function recortarParaBlob(
   imageSrc: string,
   pixelCrop: PixelCrop,
-  outputSize = 300,
+  outputWidth = 300,
+  outputHeight?: number,
 ): Promise<Blob> {
   const image = await carregarImagem(imageSrc);
   const canvas = document.createElement("canvas");
   const ctx = canvas.getContext("2d");
   if (!ctx) throw new Error("Canvas 2D não suportado.");
 
-  canvas.width = outputSize;
-  canvas.height = outputSize;
+  // Se a altura não foi fornecida, calcule preservando a proporção do recorte
+  const outH = typeof outputHeight === "number"
+    ? outputHeight
+    : Math.max(1, Math.round(outputWidth * (pixelCrop.height / pixelCrop.width)));
+
+  canvas.width = outputWidth;
+  canvas.height = outH;
+
+  // Melhor qualidade de interpolação ao redimensionar
+  ctx.imageSmoothingEnabled = true;
+  // Alguns ambientes TS não tipam imageSmoothingQuality; usar como any evita erro
+  try {
+    (ctx as CanvasRenderingContext2D & { imageSmoothingQuality?: 'low' | 'medium' | 'high' }).imageSmoothingQuality = "high";
+  } catch {
+    // ignore se não suportado
+  }
 
   ctx.drawImage(
     image,
@@ -38,8 +53,8 @@ export async function recortarParaBlob(
     pixelCrop.height,
     0,
     0,
-    outputSize,
-    outputSize,
+    canvas.width,
+    canvas.height,
   );
 
   return new Promise((resolve, reject) => {
@@ -48,8 +63,8 @@ export async function recortarParaBlob(
         if (blob) resolve(blob);
         else reject(new Error("Falha ao gerar blob da imagem."));
       },
+      // PNG é lossless; se precisar controlar qualidade use 'image/jpeg'
       "image/png",
-      0.9,
     );
   });
 }

--- a/lib/dice.ts
+++ b/lib/dice.ts
@@ -1,24 +1,148 @@
 // Lógica de rolagem de dados — pura, sem DOM.
 
 export type Dado = { faces: number; sinal: 1 | -1 };
-export type DadoRolado = { faces: number; sinal: 1 | -1; resultado: number };
+export type ModoRolagem = "normal" | "vantagem" | "desvantagem";
+
+export type DadoRolado = {
+  faces: number;
+  sinal: 1 | -1;
+  resultado: number;
+  vantagem?: {
+    modo: Exclude<ModoRolagem, "normal">;
+    candidatos: [number, number];
+    descartado: number;
+  };
+};
 
 export type ResultadoRolagem = {
   total: number;
   detalhes: DadoRolado[];
   modificador: number;
+  modo: ModoRolagem;
 };
 
-export function rolarDados(dados: Dado[], modificador: number): ResultadoRolagem {
+export type ResultadoLote = {
+  modo: ModoRolagem;
+  quantidade: number;
+  modificador: number;
+  execucoes: ResultadoRolagem[];
+};
+
+function rolarFace(faces: number): number {
+  return Math.floor(Math.random() * faces) + 1;
+}
+
+function escolherComModo(
+  primeiro: number,
+  segundo: number,
+  modo: Exclude<ModoRolagem, "normal">,
+) {
+  if (modo === "vantagem") {
+    return primeiro >= segundo
+      ? { resultado: primeiro, descartado: segundo }
+      : { resultado: segundo, descartado: primeiro };
+  }
+  return primeiro <= segundo
+    ? { resultado: primeiro, descartado: segundo }
+    : { resultado: segundo, descartado: primeiro };
+}
+
+export function rolarDados(
+  dados: Dado[],
+  modificador: number,
+  modo: ModoRolagem = "normal",
+): ResultadoRolagem {
   let total = 0;
   const detalhes: DadoRolado[] = [];
+  let vantagemConsumida = false;
+
   for (const d of dados) {
-    const resultado = Math.floor(Math.random() * d.faces) + 1;
+    if (!vantagemConsumida && modo !== "normal" && d.sinal === 1 && d.faces === 20) {
+      const primeiro = rolarFace(d.faces);
+      const segundo = rolarFace(d.faces);
+      const escolhido = escolherComModo(primeiro, segundo, modo);
+      total += escolhido.resultado * d.sinal;
+      detalhes.push({
+        faces: d.faces,
+        sinal: d.sinal,
+        resultado: escolhido.resultado,
+        vantagem: {
+          modo,
+          candidatos: [primeiro, segundo],
+          descartado: escolhido.descartado,
+        },
+      });
+      vantagemConsumida = true;
+      continue;
+    }
+
+    const resultado = rolarFace(d.faces);
     total += resultado * d.sinal;
     detalhes.push({ faces: d.faces, sinal: d.sinal, resultado });
   }
+
   total += modificador;
-  return { total, detalhes, modificador };
+  return { total, detalhes, modificador, modo };
+}
+
+export function rolarLote(
+  dados: Dado[],
+  modificador: number,
+  quantidade: number,
+  modo: ModoRolagem = "normal",
+): ResultadoLote {
+  const execucoes: ResultadoRolagem[] = [];
+  const totalExecucoes = Math.max(1, Math.trunc(quantidade || 0));
+
+  for (let indice = 0; indice < totalExecucoes; indice += 1) {
+    execucoes.push(rolarDados(dados, modificador, modo));
+  }
+
+  return {
+    modo,
+    quantidade: totalExecucoes,
+    modificador,
+    execucoes,
+  };
+}
+
+function destacarNumero(valor: number, faces: number): string {
+  if (valor === 1) return `<span class="crit-fail">${valor}</span>`;
+  if (valor === faces) return `<span class="crit-success">${valor}</span>`;
+  return `${valor}`;
+}
+
+function destacarDescartado(valor: number): string {
+  return `<span class="dice-discarded">${valor}</span>`;
+}
+
+export function formatarDadoRoladoHtml(dado: DadoRolado, incluirSinal = true): string {
+  const op = incluirSinal && dado.sinal === -1 ? "- " : "";
+  if (dado.vantagem) {
+    const usados = destacarNumero(dado.resultado, dado.faces);
+    const descartado = destacarDescartado(dado.vantagem.descartado);
+    return `${op}(${usados} / ${descartado}) 1d${dado.faces}`;
+  }
+
+  return `${op}(${destacarNumero(dado.resultado, dado.faces)}) 1d${dado.faces}`;
+}
+
+export function formatarResultadoRolagemHtml(resultado: {
+  detalhes: DadoRolado[];
+  modificador: number;
+}): string {
+  let stringFinal = "";
+  resultado.detalhes.forEach((d, i) => {
+    const op =
+      i === 0 ? (d.sinal === -1 ? "- " : "") : d.sinal === 1 ? " + " : " - ";
+    stringFinal += `${op}${formatarDadoRoladoHtml(d, false)}`;
+  });
+
+  if (resultado.modificador !== 0) {
+    stringFinal += ` ${resultado.modificador >= 0 ? "+" : "-"} ${Math.abs(resultado.modificador)}`;
+  }
+
+  return stringFinal;
 }
 
 export function formulaTexto(dados: Dado[], modificador: number): string {

--- a/lib/presets.ts
+++ b/lib/presets.ts
@@ -1,6 +1,7 @@
 // Presets de rolagem em localStorage. Chave por usuário.
 
 import type { Dado } from "./dice";
+import type { ModoRolagem } from "./dice";
 
 const STORAGE_PREFIX = "rpgo-presets-";
 
@@ -9,7 +10,17 @@ export type Preset = {
   nome: string;
   dados: Dado[];
   modificador: number;
+  modoRolagem: ModoRolagem;
+  quantidade: number;
 };
+
+function normalizarPreset(preset: Partial<Preset> & { id: string; nome: string; dados: Dado[]; modificador: number }): Preset {
+  return {
+    ...preset,
+    modoRolagem: preset.modoRolagem || "normal",
+    quantidade: Math.max(1, Math.trunc(preset.quantidade || 1)),
+  };
+}
 
 function key(userId: string) {
   return `${STORAGE_PREFIX}${userId}`;
@@ -18,7 +29,8 @@ function key(userId: string) {
 export function getPresets(userId: string): Preset[] {
   if (typeof localStorage === "undefined") return [];
   try {
-    return JSON.parse(localStorage.getItem(key(userId)) || "[]");
+    const lista = JSON.parse(localStorage.getItem(key(userId)) || "[]") as Array<Partial<Preset> & { id: string; nome: string; dados: Dado[]; modificador: number }>;
+    return lista.map(normalizarPreset);
   } catch {
     return [];
   }
@@ -26,7 +38,7 @@ export function getPresets(userId: string): Preset[] {
 
 export function addPreset(
   userId: string,
-  { nome, dados, modificador }: Omit<Preset, "id">,
+  { nome, dados, modificador, modoRolagem, quantidade }: Omit<Preset, "id">,
 ): Preset {
   const presets = getPresets(userId);
   const novo: Preset = {
@@ -34,6 +46,8 @@ export function addPreset(
     nome,
     dados,
     modificador: modificador || 0,
+    modoRolagem: modoRolagem || "normal",
+    quantidade: Math.max(1, Math.trunc(quantidade || 1)),
   };
   presets.push(novo);
   localStorage.setItem(key(userId), JSON.stringify(presets));


### PR DESCRIPTION
O calendário agora é carregado e renderizado dentro da própria visão do narrador, com realtime acoplado, em vez de apenas abrir uma página separada.
Foi criado o fluxo de “Pedir Teste” no narrador, com modal, ação de persistência e mensagens de teste no chat.
A criação/edição de mesa ganhou upload de banner com recorte antes do envio ao Storage.
O rolador da bandeja passou a suportar vantagem, desvantagem, lotes de rolagens e renderização compacta dos resultados no chat.
Os presets do rolador agora guardam e reproduzem modo de rolagem e quantidade de repetições.
Houve ajustes de tema/hidratação para reduzir mismatch entre SSR e client.